### PR TITLE
adding rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Sets the [`toolchain`](https://rust-lang.github.io/rustup/overrides.html#default-toolchain) for rust-development