### PR TITLE
Badges + Clippy Warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           git push
 
       - name: Check best practices (Clippy)
-        run: cargo clippy --verbose
+        run: cargo clippy --verbose -- -Dwarnings
 
       - name: Check for build errors
         run: cargo check --verbose

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   ![Commit Activity]
   ![Last Commit]
   ![Top Language]
+  ![Build with Nix Flakes]
   ![Open Issues]
   ![Open PullRequests]
   ![License]
@@ -33,6 +34,7 @@ tool which should run on X11 as good as on Wayland.
 [Commit Activity]: https://img.shields.io/github/commit-activity/m/eneoli/flakeshot/main
 [Last Commit]: https://img.shields.io/github/last-commit/eneoli/flakeshot
 [Top Language]: https://img.shields.io/github/languages/top/eneoli/flakeshot
+[Build with Nix Flakes]: https://img.shields.io/badge/build_with-Nix_Flakes-blue
 [Open Issues]: https://img.shields.io/github/issues/eneoli/flakeshot
 [Open PullRequests]: https://img.shields.io/github/issues-pr/eneoli/flakeshot
 [License]: https://img.shields.io/github/license/eneoli/flakeshot

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-A screenshot tool for unix-systems which runs natively on `Wayland` *and* `X11`.
+<div align="center">
+  <h1>❄ Flakeshot 📷</h1>
+
+  ![GitHub Workflow]
+  ![Commit Activity]
+  ![Last Commit]
+  ![Top Language]
+  ![Open Issues]
+  ![Open PullRequests]
+  ![License]
+  ![Repo Size]
+  ![Work in Progress]
+
+  A screenshot tool for unix-systems which runs natively on `Wayland` *and* `X11`.
+</div>
 
 # Motivation
 We all know some screenshot tools like [flameshot] (for X11) or [grim] (for Wayland) but they
@@ -8,5 +22,19 @@ tool which should run on X11 as good as on Wayland.
 # Status
 `flakeshot` is still under heavy development and not considered useable.
 
+<!-----------------------{ Links }---------------------------->
+
 [flameshot]: https://github.com/flameshot-org/flameshot
 [grim]: https://sr.ht/~emersion/grim/
+
+<!-----------------------{ Badges }--------------------------->
+
+[GitHub Workflow]: https://github.com/eneoli/flakeshot/actions/workflows/ci.yml/badge.svg
+[Commit Activity]: https://img.shields.io/github/commit-activity/m/eneoli/flakeshot/main
+[Last Commit]: https://img.shields.io/github/last-commit/eneoli/flakeshot
+[Top Language]: https://img.shields.io/github/languages/top/eneoli/flakeshot
+[Open Issues]: https://img.shields.io/github/issues/eneoli/flakeshot
+[Open PullRequests]: https://img.shields.io/github/issues-pr/eneoli/flakeshot
+[License]: https://img.shields.io/github/license/eneoli/flakeshot
+[Repo Size]: https://img.shields.io/github/repo-size/eneoli/flakeshot
+[Work in Progress]: https://img.shields.io/badge/WORK_IN_PROGRESS-red

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   ![Repo Size]
   ![Work in Progress]
 
-  A screenshot tool for unix-systems which runs natively on `Wayland` *and* `X11`.
+  #### A screenshot tool for unix-systems which runs natively on `Wayland` *and* `X11`.
 </div>
 
 # Motivation

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -28,12 +28,12 @@ pub enum Error {
 /// and returns it.
 ///
 /// # Example
-/// ```no_run
+/// ```no_run,no_test
 /// use flakeshot::backend::x11::get_images;
 /// use std::fs::File;
 /// use image::ImageOutputFormat;
 ///
-/// fn save_screenshot() {
+/// fn main() {
 ///     let mut file = File::create("./targets/example_screenshot.png").unwrap();
 ///     let images = get_images().unwrap();
 ///

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -33,7 +33,7 @@ pub enum Error {
 /// use std::fs::File;
 /// use image::ImageOutputFormat;
 ///
-/// fn main() {
+/// fn save_screenshot() {
 ///     let mut file = File::create("./targets/example_screenshot.png").unwrap();
 ///     let images = get_images().unwrap();
 ///

--- a/src/backend/x11.rs
+++ b/src/backend/x11.rs
@@ -28,7 +28,7 @@ pub enum Error {
 /// and returns it.
 ///
 /// # Example
-/// ```no_run,no_test
+/// ```no_test
 /// use flakeshot::backend::x11::get_images;
 /// use std::fs::File;
 /// use image::ImageOutputFormat;


### PR DESCRIPTION
- Adds some badges to the readme
- Let's CI fail when clippy emits a warning

[Click here](https://github.com/eneoli/flakeshot/blob/fbdd7b218cbe3d92b1a19bb4f9d566f94e4c580e/README.md) to see a render of the new readme.