### PR TITLE
rust-toolchain: adding rust-analyzer

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,7 +1,0 @@
-[language-server.rust-analyzer]
-command = "rust-analyzer"
-config = { procMacro = { enable = true } } 
-
-[[language]]
-name = "rust"
-language-servers = ["rust-analyzer"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly-2023-11-25"
-components = ["rustc-codegen-cranelift"]
+components = ["rustc-codegen-cranelift", "rust-analyzer"]


### PR DESCRIPTION
This adds the rust-analyzer for the specifique nightly version for development.