### PR TITLE
Add notification system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.2.0",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +295,12 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -490,6 +522,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +560,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -680,6 +742,7 @@ dependencies = [
  "image",
  "ksni",
  "memfd",
+ "notify-rust",
  "relm4",
  "relm4-icons",
  "rustix 0.38.31",
@@ -792,7 +855,10 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
+ "fastrand 2.0.1",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -1224,7 +1290,7 @@ checksum = "0bb9136c388a1e7b3017d18fe7c2f263b0a2b13f215c48e8eb44935d413ce0f9"
 dependencies = [
  "byteorder",
  "flate2",
- "quick-xml",
+ "quick-xml 0.31.0",
  "safe-transmute",
  "serde",
  "serde_json",
@@ -1385,6 +1451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1488,28 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fca4d74ff9dbaac16a01b924bc3693fa2bba0862c2c633abc73f9a8ea21f64"
+dependencies = [
+ "cc",
+ "dirs-next",
+ "objc-foundation",
+ "objc_id",
+ "time",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1497,6 +1596,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "827c5edfa80235ded4ab3fe8e9dc619b4f866ef16fe9b1c6b8a7f8692c0f2226"
+dependencies = [
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1617,12 @@ dependencies = [
  "overload",
  "winapi",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -1523,6 +1641,35 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -1660,6 +1807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1793,6 +1955,26 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2140,6 +2322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006851c9ccefa3c38a7646b8cec804bb429def3da10497bfa977179869c3e8e2"
+dependencies = [
+ "quick-xml 0.30.0",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2383,25 @@ dependencies = [
  "jpeg-decoder",
  "weezl",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tokio"
@@ -2530,7 +2741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.31.0",
  "quote",
 ]
 
@@ -2581,6 +2792,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2769,9 +2999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "byteorder",
  "derivative",
  "enumflags2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ anyhow = "1.0"
 memfd = "0.6"
 xdg = "2.5"
 ksni = { git = "https://github.com/talonvoice/ksni/", branch = "zbus" }
-rustix = "0.38.31"
+rustix = "0.38"
 tokio = "1.36"
 derive-where = "1.2"
+notify-rust = "4.10"

--- a/src/frontend/ui/ui_manager.rs
+++ b/src/frontend/ui/ui_manager.rs
@@ -243,7 +243,7 @@ impl UiManager {
         };
 
         img.write_to(&mut Cursor::new(&mut image_bytes), ImageOutputFormat::Png)
-            .context("Couldn't write image to stdin of clipboard process");
+            .context("Couldn't write image to stdin of clipboard process")?;
 
         let child_stdin = child
             .stdin

--- a/src/frontend/ui/ui_manager.rs
+++ b/src/frontend/ui/ui_manager.rs
@@ -212,7 +212,7 @@ impl UiManager {
                         msg: format!(
                             "Couldn't save screenshot to {}: {}",
                             path.to_string_lossy(),
-                            err.to_string()
+                            err
                         ),
                         urgency: Urgency::Critical,
                     }),

--- a/src/frontend/window/main_window.rs
+++ b/src/frontend/window/main_window.rs
@@ -67,21 +67,15 @@ impl AppModel {
     }
 
     fn notify(&self, msg: String, urgency: Urgency) {
-        let handle = std::thread::spawn(move || {
-            if let Err(err) = Notification::new()
-                .appname(crate_name!())
-                .urgency(urgency)
-                .summary(FLAKESHOT_SUMMARY)
-                .body(&msg)
-                .show()
-            {
-                error!("Couldn't show notification: {}", err);
-            }
-        });
-
-        handle
-            .join()
-            .expect("An error occured while creating a notification.");
+        if let Err(err) = Notification::new()
+            .appname(crate_name!())
+            .urgency(urgency)
+            .summary(FLAKESHOT_SUMMARY)
+            .body(&msg)
+            .show()
+        {
+            error!("Couldn't show notification: {}", err);
+        }
     }
 
     /// Start a new GUI session where a screenshot of all monitors

--- a/src/frontend/window/main_window.rs
+++ b/src/frontend/window/main_window.rs
@@ -69,7 +69,7 @@ impl AppModel {
     fn notify(&self, msg: String, urgency: Urgency) {
         let handle = std::thread::spawn(move || {
             if let Err(err) = Notification::new()
-                .appname(&crate_name!())
+                .appname(crate_name!())
                 .urgency(urgency)
                 .summary(FLAKESHOT_SUMMARY)
                 .body(&msg)

--- a/src/frontend/window/main_window.rs
+++ b/src/frontend/window/main_window.rs
@@ -52,6 +52,8 @@ pub enum Command {
 
     /// Tells [`AppModel`] to open up the GUI.
     Gui,
+
+    /// Tells [`AppModel`] to create a notification.
     Notify(Notification),
 }
 

--- a/src/frontend/window/main_window.rs
+++ b/src/frontend/window/main_window.rs
@@ -18,6 +18,8 @@ use notify_rust::{Notification, Urgency};
 use relm4::{gtk::Application, prelude::*};
 use tracing::error;
 
+const FLAKESHOT_SUMMARY: &str = "Flakeshot info";
+
 #[derive(Debug)]
 pub enum AppInput {
     ScreenshotWindowOutput(ScreenshotWindowOutput),
@@ -69,7 +71,7 @@ impl AppModel {
             if let Err(err) = Notification::new()
                 .appname(&crate_name!())
                 .urgency(urgency)
-                .summary(&crate_name!())
+                .summary(FLAKESHOT_SUMMARY)
                 .body(&msg)
                 .show()
             {

--- a/src/frontend/window/mod.rs
+++ b/src/frontend/window/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_chooser;
 pub mod main_window;
+pub mod notification;
 pub mod run_mode;
 pub mod screenshot_window;

--- a/src/frontend/window/notification.rs
+++ b/src/frontend/window/notification.rs
@@ -1,0 +1,7 @@
+use notify_rust::Urgency;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Notification {
+    pub msg: String,
+    pub urgency: Urgency,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn trace_panics() {
         // we are already in a panic hook, if that panics as well... then we are
         // entering a recursion loop so we're just ignoring the result
         let _ = Notification::new()
-            .appname(&clap::crate_name!())
+            .appname(clap::crate_name!())
             .urgency(notify_rust::Urgency::Critical)
             .summary("Flakeshot paniced!")
             .body(concat![

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ compile_error!("flakeshot only runs on UNIX-like systems.");
 use clap::Parser;
 use flakeshot::cli::Cli;
 use flakeshot::frontend::window::run_mode::RunMode;
+use notify_rust::Notification;
 
 fn main() {
     trace_panics();
@@ -18,5 +19,18 @@ fn trace_panics() {
     std::panic::set_hook(Box::new(move |panic_info| {
         tracing_panic::panic_hook(panic_info);
         prev_hook(panic_info);
+
+        // we are already in a panic hook, if that panics as well... then we are
+        // entering a recursion loop so we're just ignoring the result
+        let _ = Notification::new()
+            .appname(&clap::crate_name!())
+            .urgency(notify_rust::Urgency::Critical)
+            .summary("Flakeshot paniced!")
+            .body(concat![
+                "You likely found a bug. ",
+                "Please take a look into the log file (see `flakeshot -h`) and ",
+                "create an issue if suitable."
+            ])
+            .show();
     }));
 }


### PR DESCRIPTION
Closes https://github.com/eneoli/flakeshot/issues/101

So the main changes are regarding the save options:
It'll prompt a little notification after saving the image to the clipboard/file chooser:

![image](https://github.com/eneoli/flakeshot/assets/50843046/eb9639fb-6424-4988-bcb0-142fccaf67f2)

Also I didn't convert most of the `.expect` calls to notifications, because they're often in places which are verifying the internal behaviour of flakeshot (like cropping the image). If one of those `excepts` fire, than this means that there's an internal error in flakeshot hence it doesn't help to inform the user that he can't use the tool.